### PR TITLE
fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ await initialize(); // make sure to initialize first!
 
 const data: Uint8Array = await Deno.readFile("image.jpg");
 
-await ImageMagick.read(data, (img: IMagickImage) => {
+await ImageMagick.read(data, async (img: IMagickImage) => {
   img.resize(200, 100);
   img.blur(20, 6);
 


### PR DESCRIPTION
Not a big deal, but currently copypasta-ing the readme example is a syntax error for the nested await:

```
error: Uncaught SyntaxError: Unexpected reserved word
  await img.write(
  ^
```