### PR TITLE
feat: optionally skip caching of wasm file

### DIFF
--- a/deno/mod.ts
+++ b/deno/mod.ts
@@ -1,7 +1,17 @@
 export * from "./src/index.ts";
 import { initializeImageMagick } from "./src/index.ts";
 
-export async function initialize() {
+type InitOptions = {
+  useCache: boolean;
+};
+
+const DEFAULT_OPTIONS: InitOptions = {
+  useCache: true,
+};
+
+export async function initialize(paramOptions: Partial<InitOptions> = {}) {
+  const options = { ...DEFAULT_OPTIONS, ...paramOptions };
+
   const wasmUrl = new URL(import.meta.resolve("./src/wasm/magick_native.wasm"));
 
   if (wasmUrl.protocol === "file:") {
@@ -9,7 +19,7 @@ export async function initialize() {
     return;
   }
 
-  if (typeof caches === "undefined") {
+  if (!options.useCache || typeof caches === "undefined") {
     const response = await fetch(wasmUrl);
     await initializeImageMagick(new Int8Array(await response.arrayBuffer()));
     return;


### PR DESCRIPTION
deploying `imagemagick` to deno cloud crashes the app, with this error (caching issues):

```
Error: cache PUT request failed: 500 Internal Server Error
    at async Cache.put (ext:deno_cache/01_cache.js:155:5)
    at async initialize (https://deno.land/x/imagemagick_deno@0.0.26/mod.ts:33:3)
    at async Object.configResolved (file:///src/plugins/image-resize.ts:96:7)
    at async Promise.all (index 1)
    at async getServerContext (https://deno.land/x/fresh@1.6.8/src/server/context.ts:77:5)
    at async start (https://deno.land/x/fresh@1.6.8/src/server/mod.ts:110:15)
    at async file:///src/main.ts:13:1
```

it fails here:
https://github.com/lumeland/imagemagick-deno/blob/81859c71aa19eb0e7278928b459cab5a1395f312/deno/mod.ts#L33